### PR TITLE
Fix to parse out CR when reading aws credentials

### DIFF
--- a/aws_extender_cli.py
+++ b/aws_extender_cli.py
@@ -39,8 +39,8 @@ def init_clients(keys_path, service):
         with open(keys_path, 'r') as fkeys:
             keys = fkeys.read()
             try:
-                access_key = re.search(r'AccessKeyId[=:]([^\n]+)', keys, re.I).group(1)
-                secret_key = re.search(r'SecretKey[=:]([^\n]+)', keys, re.I).group(1)
+                access_key = re.search(r'AccessKeyId[=:]([^\n\r]+)', keys, re.I).group(1)
+                secret_key = re.search(r'SecretKey[=:]([^\n\r]+)', keys, re.I).group(1)
             except AttributeError:
                 raise ValueError('Credentials are not in the right format. '
                                  'The expected format is:\nAccessKeyId=XXXX\nSecretKey=XXXX')


### PR DESCRIPTION
Traceback (most recent call last):
  File "aws_extender_cli.py", line 500, in <module>
    main()
  File "aws_extender_cli.py", line 489, in main
    issue = test_fn(bucket, clients, wordlist_path)
  File "aws_extender_cli.py", line 102, in test_s3_bucket
    client.head_bucket(Bucket=bucket_name)
  File "/home/ciara/.local/lib/python2.7/site-packages/botocore/client.py", line 314, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/home/ciara/.local/lib/python2.7/site-packages/botocore/client.py", line 599, in _make_api_call
    operation_model, request_dict)
  File "/home/ciara/.local/lib/python2.7/site-packages/botocore/endpoint.py", line 143, in make_request
    return self._send_request(request_dict, operation_model)
  File "/home/ciara/.local/lib/python2.7/site-packages/botocore/endpoint.py", line 172, in _send_request
    success_response, exception):
  File "/home/ciara/.local/lib/python2.7/site-packages/botocore/endpoint.py", line 265, in _needs_retry
    caught_exception=caught_exception, request_dict=request_dict)
  File "/home/ciara/.local/lib/python2.7/site-packages/botocore/hooks.py", line 227, in emit
    return self._emit(event_name, kwargs)
  File "/home/ciara/.local/lib/python2.7/site-packages/botocore/hooks.py", line 210, in _emit
    response = handler(**kwargs)
  File "/home/ciara/.local/lib/python2.7/site-packages/botocore/retryhandler.py", line 183, in __call__
    if self._checker(attempts, response, caught_exception):
  File "/home/ciara/.local/lib/python2.7/site-packages/botocore/retryhandler.py", line 251, in __call__
    caught_exception)
  File "/home/ciara/.local/lib/python2.7/site-packages/botocore/retryhandler.py", line 269, in _should_retry
    return self._checker(attempt_number, response, caught_exception)
  File "/home/ciara/.local/lib/python2.7/site-packages/botocore/retryhandler.py", line 317, in __call__
    caught_exception)
  File "/home/ciara/.local/lib/python2.7/site-packages/botocore/retryhandler.py", line 223, in __call__
    attempt_number, caught_exception)
  File "/home/ciara/.local/lib/python2.7/site-packages/botocore/retryhandler.py", line 359, in _check_caught_exception
    raise caught_exception
ValueError: Invalid header value 'AWS4-HMAC-SHA256 Credential=[REDACTED]\r/20180226/us-east-2/s3/aws4_request, SignedHeaders=host;xxxxxx;x-amz-date, Signature=[REDACTED]'