### PR TITLE
Allow the script to understand the file format of ~/.aws/credentials.

### DIFF
--- a/aws_extender_cli.py
+++ b/aws_extender_cli.py
@@ -45,8 +45,8 @@ def init_clients(keys_path, service):
         with open(keys_path, 'r') as fkeys:
             keys = fkeys.read()
             try:
-                access_key = re.search(r'access_?key_?id\s*[=:]\s*([^\s]+)', keys, re.I).group(1)
-                secret_key = re.search(r'secret(?:_access_)?key\s*[=:]\s*([^\s]+)', keys, re.I).group(1)
+                access_key = re.search(r'access_?key_?id ?[=:] ?([^\s]+)', keys, re.I).group(1)
+                secret_key = re.search(r'secret(?:_access_)?key ?[=:] ?([^\s]+)', keys, re.I).group(1)
             except AttributeError:
                 raise ValueError('Credentials are not in the expected format. '
                                  'The expected format is:\naws_access_key_id=XXXX\naws_secret_access_key=XXXX')

--- a/aws_extender_cli.py
+++ b/aws_extender_cli.py
@@ -45,8 +45,8 @@ def init_clients(keys_path, service):
         with open(keys_path, 'r') as fkeys:
             keys = fkeys.read()
             try:
-                access_key = re.search(r'access_?key_?id[=:]([^\s]+)', keys, re.I).group(1)
-                secret_key = re.search(r'secret(?:_access_)?key[=:]([^\s]+)', keys, re.I).group(1)
+                access_key = re.search(r'access_?key_?id\s*[=:]\s*([^\s]+)', keys, re.I).group(1)
+                secret_key = re.search(r'secret(?:_access_)?key\s*[=:]\s*([^\s]+)', keys, re.I).group(1)
             except AttributeError:
                 raise ValueError('Credentials are not in the expected format. '
                                  'The expected format is:\naws_access_key_id=XXXX\naws_secret_access_key=XXXX')


### PR DESCRIPTION
The `~/.aws/credentials` file is produced by `aws configure` and has spaces on either side of the equals sign. Given just a single account (or the desired creds being the first set), this RE is still able to pull them out by accepting the spaces.